### PR TITLE
Check that rootInActiveWindow is not null before recursive search.

### DIFF
--- a/AndroidProject/app/src/main/java/com/livescrolltranscript/LiveScrollTranscriptAccessibilityService.kt
+++ b/AndroidProject/app/src/main/java/com/livescrolltranscript/LiveScrollTranscriptAccessibilityService.kt
@@ -102,8 +102,9 @@ class LiveScrollTranscriptAccessibilityService : AccessibilityService() {
 
     /** Recursive function to find nodes that contain [word]. Recycles nodes that don't match. */
     private fun getNodesContainingWord(
-        word: String, root: AccessibilityNodeInfo, result: MutableSet<AccessibilityNodeInfo>
+        word: String, root: AccessibilityNodeInfo?, result: MutableSet<AccessibilityNodeInfo>
     ) {
+        if (root == null) return
         if (root.containsWord(word)) result.add(root)
         for (i in 1..root.childCount) {
             root.getChild(i - 1)?.let { getNodesContainingWord(word, it, result) }


### PR DESCRIPTION
This prevents an IllegalState exception which crashes the accessibility service if root is null (for example if captions scroll and window is requested while a user is switching between apps).